### PR TITLE
Fix the argument order for LedController in LCDemo7Segment

### DIFF
--- a/examples/english/LCDemo7Segment/LCDemo7Segment.ino
+++ b/examples/english/LCDemo7Segment/LCDemo7Segment.ino
@@ -34,7 +34,7 @@ unsigned long delaytime=250;
 void setup() {
 
   //Here a new LedController object is created without hardware SPI.
-  lc=LedController<1,1>(CS,CLK,DIN);
+  lc=LedController<1,1>(DIN,CLK,CS);
 
   /* Set the brightness to a medium values */
   lc.setIntensity(8);


### PR DESCRIPTION
Tested locally on an ESP32 Dev Module and also follows the [documentation](https://ledcontroller.noasakurajin.de/english/d6/df8/classsakurajin_1_1_led_controller.html#ae50febdae23344375a3e3fe8d50cf4f0)